### PR TITLE
Add name to local relay

### DIFF
--- a/guition-esp32-s3-4848s040-display_modular.yaml
+++ b/guition-esp32-s3-4848s040-display_modular.yaml
@@ -75,6 +75,7 @@ packages:
     file: modules/sensors/local_relay_button_state.yaml
     vars:
       uid: button_1
+      ha_name: Light 1
       entity_id: internal_relay_1
   # Button 2 - Standard light button with state updates
   button_2_state: !include

--- a/modules/sensors/local_relay_button_state.yaml
+++ b/modules/sensors/local_relay_button_state.yaml
@@ -2,10 +2,12 @@
 # Local relay as light or switch
 # vars:
   # uid:
+  # ha_name:
   # entity_id:
 
 light:
   - id: local_light_${uid}
+    name: ${ha_name}
     platform: binary
     output: $entity_id
     on_turn_on:


### PR DESCRIPTION
Fixing #3 

So this is what I was thinking to make the relays visible and controllable in Home Assistant.

But it can as well be achieved by adding something like this in the main yaml config. Which is not very hard.
```yaml
light:
  - id: !extend local_light_button_1  # Full id of light entity "local_light_${uid}"
    name: Light 1
  - id: !extend local_light_button_2
    name: Light 2
  - id: !extend local_light_button_3
    name: Light 3
```