### PR TITLE
A fresh look at esp32 config to better align with official ESP Home esp32 examples.

### DIFF
--- a/hardware/waveshare-esp32-s3-touch-lcd-7.yaml
+++ b/hardware/waveshare-esp32-s3-touch-lcd-7.yaml
@@ -15,14 +15,11 @@ esphome:
     board_upload.maximum_ram_size: 524288
 
 esp32:
-  board: esp32-s3-devkitc1-n16r8
+  variant: esp32s3
+  flash_size: 8MB
   cpu_frequency: 240MHz
   framework:
     type: esp-idf
-    sdkconfig_options:
-      CONFIG_BOOTLOADER_FLASH_DC_AWARE: n     # After the first upload you may
-      CONFIG_SPI_FLASH_HPM_DC_DISABLE: y      # have to press the reset button on the back
-      CONFIG_ESP_CONSOLE_USB_CDC: y           # these options fix that for further OTA updates
 
 psram:
   mode: octal


### PR DESCRIPTION
For example: [Use esp32 variant instead of board](https://github.com/esphome/bluetooth-proxies/pull/128).

I noticed that the flash size specified in the board json is ignored - and probably a lot of other bits as well, for example: despite the following output without flash_size being specified when installing:

`HARDWARE: ESP32S3 240MHz, 512KB RAM, 8MB Flash`

There's not enough room as it defaults to 1.75MB:

```
HARDWARE: ESP32S3 240MHz, 512KB RAM, 8MB Flash

<le snip>

Creating ESP32S3 image...
Successfully created ESP32S3 image.
Linking .pioenvs/waveshare-7inch/firmware.elf
usage: esp_idf_size [-h] [--format {table,text,tree,csv,json2,raw,dot}]
                    [--archives] [--archive-dependencies] [--dep-symbols]
                    [--dep-reverse] [--archive-details ARCHIVE_NAME] [--files]
                    [--diff MAP_FILE] [--no-abbrev] [--unify] [--show-unused]
                    [--show-unchanged] [--use-flash-size] [--lto] [-d]
                    [-o OUTPUT_FILE] [-s COLUMN] [-F PATTERN] [--sort-diff]
                    [--sort-reverse] [-q] [--no-color] [--force-terminal]
                    [--doc]
                    MAP_FILE
RAM:   [=         ]   7.5% (used 39340 bytes from 524288 bytes)
Flash: [==========]  112.2% (used 2057986 bytes from 1835008 bytes)
Error: The program size (2057986 bytes) is greater than maximum allowed (1835008 bytes)
*** [checkprogsize] Explicit exit, status 1
========================= [FAILED] Took 55.33 seconds =========================
```

I can change this to 16MB as per the previous version if needed.

This has been tested on both a good device that supports 120MHz of PSRAM, and another dodgy one that only supports 80MHz.

Additionally, the reset after OTA update problem has gone - so no need for the additional `sdkconfig_options`.