### PR TITLE
Stop the screen flashing during OTA updates for JC1060P470 (and other esp32p4's)

### DIFF
--- a/hardware/guition-esp32-p4-jc1060p470.yaml
+++ b/hardware/guition-esp32-p4-jc1060p470.yaml
@@ -14,6 +14,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
+    sdkconfig_options:
+      CONFIG_SPIRAM_XIP_FROM_PSRAM: y   # To stop the screen flashing during OTA updates
     advanced:
       enable_idf_experimental_features: yes
 


### PR DESCRIPTION
As per the [Home Assistant Forum Guition esp32-p4-jc1060p470 thread](https://community.home-assistant.io/t/guition-esp32-p4-jc1060p470/959144/12?u=gingermist) Clyde has a fix for OTA flashing for the esp32p4.