### PR TITLE
Add hardware profile for Espressif ESP32-S3-Box-3

### DIFF
--- a/hardware/esp32-s3-box-3.yaml
+++ b/hardware/esp32-s3-box-3.yaml
@@ -1,0 +1,105 @@
+# Espressif 2.4” ESP32-S3-BOX-3 Capacitive Touch Display 320x240 SPI Display
+# 512KB SRAM and 384KB ROM, with onboard 16MB Flash and 16MB PSRAM
+# https://www.espressif.com/en/dev-board/esp32-s3-box-3-en
+# Hardware configuration file
+
+esphome:
+  min_version: 2025.11.0
+  project:
+    name: "Espressif.ESP32-S3-BOX-3"
+    version: "1.0.0"
+
+esp32:
+  board: esp32s3box
+  flash_size: 16MB
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"
+      CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
+      CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"
+      CONFIG_PM_ENABLE: "y"  # Enable power management
+      CONFIG_PM_DFS_INIT_AUTO: "y"  # Enable automatic dynamic frequency scaling
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+preferences:
+  flash_write_interval: 5min
+
+#-------------------------------------------
+# LCD Back light
+#-------------------------------------------
+output:
+  - platform: ledc
+    pin: GPIO47
+    id: display_backlight_output
+
+light:
+  - platform: monochromatic
+    id: display_backlight
+    name: LCD Backlight
+    entity_category: config
+    output: display_backlight_output
+    restore_mode: ALWAYS_ON
+    default_transition_length: 250ms    
+
+#-------------------------------------------
+# Touchscreen gt911
+#-------------------------------------------
+i2c:
+  - id: bus_a
+    sda: GPIO08
+    scl: GPIO18
+    scan: true
+    sda_pullup_enabled: true
+    scl_pullup_enabled: true
+    frequency: 100kHz
+
+  - sda: GPIO41
+    scl: GPIO40
+    scan: true
+    sda_pullup_enabled: true
+    scl_pullup_enabled: true
+    frequency: 50kHz
+    id: bus_b
+
+spi:
+  clk_pin: 7
+  mosi_pin: 6
+
+touchscreen:
+  - platform: gt911
+    i2c_id: bus_a
+    address: 0x5D
+    id: my_touchscreen
+    display: my_display
+    interrupt_pin:
+      number: GPIO3
+      ignore_strapping_warning: true
+    # on_touch:
+    #   - script.execute: track_activity
+    #   - logger.log:
+    #       format: Touch at (%d, %d)
+    #       args: [touch.x, touch.y]
+
+#-------------------------------------------
+# Display
+#-------------------------------------------
+display:
+  - platform: ili9xxx
+    id: my_display
+    model: S3BOX
+    data_rate: 40MHz
+    dimensions:
+      width: 320
+      height: 240
+    cs_pin: 5
+    dc_pin: 4
+    reset_pin:
+      number: 48
+      inverted: true
+    update_interval: never
+    auto_clear_enabled: false
+    invert_colors: false


### PR DESCRIPTION
The Espressif Box 3 is a fun prototyping devkit. The resolution is smaller than most of the other existing hardware profiles but mostly things Just Work. The loading screen is the most obvious exception however. Later I'll try cloning & tweaking the `loading_480px.yaml` page to work on a 320x240 screen.