### PR TITLE
Define devices with "my_" prefix

### DIFF
--- a/hardware/waveshare-esp32-p4-wifi6-touch-lcd-7b.yaml
+++ b/hardware/waveshare-esp32-p4-wifi6-touch-lcd-7b.yaml
@@ -144,20 +144,20 @@ i2s_audio:
 
 audio_dac:
   - platform: es8311
-    id: es8311_dac
+    id: my_dac
     i2c_id: bus_a
     address: 0x18
 
 audio_adc:
   - platform: es7210
-    id: es7210_adc
+    id: my_adc
     i2c_id: bus_a
     address: 0x40
 
 # ===== Microphone =====
 microphone:
   - platform: i2s_audio
-    id: esp32_microphone
+    id: my_microphone
     i2s_audio_id: audio_bus
     i2s_din_pin: GPIO11
     sample_rate: 16000
@@ -171,10 +171,10 @@ microphone:
 # ===== Speaker & Audio Pipeline =====
 speaker:
   - platform: i2s_audio
-    id: esp32_speaker
+    id: my_speaker
     i2s_audio_id: audio_bus
     i2s_dout_pin: GPIO9
-    audio_dac: es8311_dac
+    audio_dac: my_dac
     dac_type: external
     channel: mono
     buffer_duration: 100ms
@@ -183,7 +183,7 @@ speaker:
 
   - platform: mixer
     id: mixing_speaker
-    output_speaker: esp32_speaker
+    output_speaker: my_speaker
     source_speakers:
       - id: announcement_mixing_input
         timeout: never


### PR DESCRIPTION
Some audio devices not defined and the audio assistant fails to validate; I mirrored changes in the waveshare-esp32-p4-86-panel.yaml file.