### PR TITLE
Add config for Waveshare ESP32 touch LCD 3.5B

### DIFF
--- a/hardware/waveshare-esp32-s3-touch-lcd-3.5b.yaml
+++ b/hardware/waveshare-esp32-s3-touch-lcd-3.5b.yaml
@@ -1,0 +1,109 @@
+esphome:
+  name: waveshare-esp32-s3-touch
+  friendly_name: WaveShare ESP32-S3 Touch LCD 3.5B
+  platformio_options:
+    board_build.arduino.memory_type: qio_opi
+    board_build.flash_mode: qio
+    #board_upload.flash_size: 16MB
+
+# Enable PSRAM
+psram:
+  mode: octal
+  speed: 80MHz
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  flash_size: 16MB
+  framework:
+    type: esp-idf
+
+# Enable logging
+logger:
+
+# QSPI configuration for AXS15231B display controller
+spi:
+  - id: quad_spi
+    type: quad
+    clk_pin: GPIO5      # LCD_SCLK
+    data_pins:
+      - GPIO1           # LCD_DATA0
+      - GPIO2           # LCD_DATA1
+      - GPIO3           # LCD_DATA2
+      - GPIO4           # LCD_DATA3
+
+# Display configuration for AXS15231B
+display:
+  - #platform: qspi_dbi
+    platform: mipi_spi
+    bus_mode: quad
+    model: AXS15231
+    id: my_display
+    data_rate: 40MHz
+    spi_mode: mode0
+    dimensions:
+      width: 320
+      height: 480
+      #width: 480
+      #height: 320
+      offset_width: 0
+      offset_height: 0
+    rotation: 90
+    color_order: rgb
+    #brightness: 255
+    cs_pin: GPIO12      # LCD_CS
+    #reset_pin:
+
+
+# Font configuration
+font:
+  - file: "gfonts://Roboto"
+    id: my_font
+    size: 40
+
+# Backlight control (LCD_BL)
+output:
+  - platform: ledc
+    pin: GPIO6
+    id: backlight_pwm
+    frequency: 5kHz
+
+light:
+  - platform: monochromatic
+    output: backlight_pwm
+    name: "Display Backlight"
+    id: display_backlight
+    restore_mode: ALWAYS_ON
+
+# I2C configuration for AXS15231B touch controller
+i2c:
+  - id: touch_i2c
+    sda: GPIO8        # TP_SDA / ESP_SDA
+    scl: GPIO7        # TP_SCL / ESP_SCL
+    scan: true
+    frequency: 400kHz
+
+# TCA9554PWR GPIO Expander, very similar to the PCA9554
+pca9554:
+  - id: tca9554_gpio_expander
+    address: 0x20     # Default I2C address for TCA9554
+    i2c_id: touch_i2c
+
+# Touchscreen configuration for AXS15231B
+touchscreen:
+  - platform: axs15231
+    display: my_display
+    id: my_touchscreen
+    i2c_id: touch_i2c
+    update_interval: 10ms    # Poll touchscreen every 10ms (100 Hz)
+    transform:
+      swap_xy: true
+      mirror_x: false
+      mirror_y: true
+    on_update:
+      - lambda: |-
+          for (auto touch: touches)  {
+              if (touch.state <= 2) {
+                ESP_LOGI("Touch points:", "id=%d x=%d, y=%d", touch.id, touch.x, touch.y);
+              }
+          }


### PR DESCRIPTION
This PR is adding a working configuration for the Waveshare 3.5inches display (see https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-3.5B).
Unlike other already supported Waveshare devices, this one does NOT use the gt911 display but rather an integrated AXS15231B LCD and Touch Panel Controller chip.