### PR TITLE
Create a modular navigation bar

### DIFF
--- a/pages/grid_4x7_side.yaml
+++ b/pages/grid_4x7_side.yaml
@@ -5,7 +5,6 @@ pages:
     styles: page_style
     <<: !include ../widgets/swipe_navigation.yaml
     widgets:
-        # You can use the package section above to add prebuilt button types or build your own custom button from scratch here.
         - container: # Button 0 (Active)
             id: ${page_0}_0
             grid_cell_x_align: stretch


### PR DESCRIPTION
This is a 4x7 grid, with 4 navigation buttons on the side, leaving a 4x6 grid for buttons. This could also have 7 buttons across the top or bottom (and get a name like grid_4x7_top.yaml).

There may be away to dynamically produce different arrangements, but this works for me for now.

The buttons are simple - I haven't made them pretty or added icons. Black with white text is the current active page, white with black text is a clickable link.

In my main file containing substitutions I included these substitutions:
```
  page_0: main_page
  page_0_title: "Main"
  page_1: sub_page
  page_1_title: "Sub 1"
  page_2: page2
  page_2_title: "2"
  page_3: page3
  page_3_title: "3"
```

My LVGL block in the main file simply includes the grid layout with sidebar:
```
lvgl:
  buffer_size: 100%
  <<: !include esphome-modular-lvgl-buttons/pages/grid_4x7_side.yaml
```

My buttons are unchanged, but they required the page_id as previously added:
```
  # Add a button the controls a light in HA  
  button_1_2: !include
    file: esphome-modular-lvgl-buttons/buttons/switch_button.yaml
    vars:
      uid: button_1_2
      page_id: ${page_3}
      row: 0
      column: 1
      text: "Basement\nLight"
      icon: $mdi_lightbulb
      entity_id: "switch.basement_master_stairwell"
```

![PXL_20260221_053746046](https://github.com/user-attachments/assets/27d7e6cd-3c43-4d71-ac16-eb6c34ef1fa3)
