### PR TITLE
Fix ESPHome 2026.4.0 compatibility

### DIFF
--- a/hardware/media_player-voice_assistant.yaml
+++ b/hardware/media_player-voice_assistant.yaml
@@ -7,7 +7,7 @@ external_components:
       type: git
       url: https://github.com/kahrendt/esphome
       ref: 7a6cf5c8472b7e2fa18ee0fc314f66a80d249e32
-    components: [const, media_source, sendspin]
+    components: [media_source, sendspin]
   - source:
       type: git
       url: https://github.com/esphome/esphome

--- a/ui/weather/forecast.yaml
+++ b/ui/weather/forecast.yaml
@@ -19,6 +19,7 @@ mapping:
       lightning: lightning_${size}
       lightning-rainy: lightning_rainy_${size}
       partlycloudy: partlycloudy_${size}
+      partlycloudy-night: partlycloudy_${size}
       pouring: pouring_${size}
       rainy: rainy_${size}
       snowy: snowy_${size}


### PR DESCRIPTION
## Summary

- **`media_player-voice_assistant.yaml`**: Remove `const` from the kahrendt external_components override. ESPHome 2026.4.0 ships `const` as a built-in with a new `KEY_METADATA` symbol that LVGL depends on — the old override shadows it, breaking compilation with `ImportError: cannot import name 'KEY_METADATA'`.
- **`ui/weather/forecast.yaml`**: Add `partlycloudy-night` condition to the icon mapping. Met.no and other European integrations return this for daily forecasts; an unmatched key returns null from the LVGL mapping, silently hiding the weather icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)