### PR TITLE
Support for glyphsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ substitutions:
   screen_width:  "480"
   screen_height: "480"
 
+  # you can use the glyphsets to support additinoal characters
+  # see also https://esphome.io/components/font/#configuration-variables
+  #
+  # glyphsets: "GF_Latin_Core"
+
 esphome:
   name: my-panel
   friendly_name: My Panel

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ substitutions:
   screen_width:  "480"
   screen_height: "480"
 
-  # you can use the glyphsets to support additinoal characters
+  # you can use the glyphsets to support additional characters
   # see also https://esphome.io/components/font/#configuration-variables
   #
   # glyphsets: "GF_Latin_Core"

--- a/common/theme/fonts.yaml
+++ b/common/theme/fonts.yaml
@@ -1,46 +1,66 @@
 ---
+# To support additional glyphs you can define the glyphsets-subsitution
+# in your main .yaml-file
+#
+# See also: https://esphome.io/components/font/#configuration-variables
+#
+# substitutions:
+#  icon_font: mdi_icons_40
+#  [... additional configuration ...]
+#  label_on_color: "white"
+#  glyphsets: "GF_Latin_Core" # <-- add this line
+
 font:
   - file: "esphome-modular-lvgl-buttons/assets/fonts/Nunito-SemiBold.ttf"
     id: nunito_72
     size: 72
     bpp: 8
+    glyphsets: ${glyphsets | default("GF_Latin_Kernel")}
 
   - file: "esphome-modular-lvgl-buttons/assets/fonts/Nunito-SemiBold.ttf"
     id: nunito_48
     size: 48
     bpp: 8
+    glyphsets: ${glyphsets | default("GF_Latin_Kernel")}
 
   - file: "esphome-modular-lvgl-buttons/assets/fonts/Nunito-SemiBold.ttf"
     id: nunito_42
     size: 42
     bpp: 8
+    glyphsets: ${glyphsets | default("GF_Latin_Kernel")}
 
   - file: "esphome-modular-lvgl-buttons/assets/fonts/Nunito-SemiBold.ttf"
     id: nunito_36
     size: 36
     bpp: 8
+    glyphsets: ${glyphsets | default("GF_Latin_Kernel")}
 
   - file: "esphome-modular-lvgl-buttons/assets/fonts/Nunito-SemiBold.ttf"
     id: nunito_24
     size: 24
     bpp: 8
+    glyphsets: ${glyphsets | default("GF_Latin_Kernel")}
 
   - file: "esphome-modular-lvgl-buttons/assets/fonts/Nunito-SemiBold.ttf"
     id: nunito_20
     size: 20
     bpp: 8
+    glyphsets: ${glyphsets | default("GF_Latin_Kernel")}
 
   - file: "esphome-modular-lvgl-buttons/assets/fonts/Nunito-SemiBold.ttf"
     id: nunito_18
     size: 18
     bpp: 8
+    glyphsets: ${glyphsets | default("GF_Latin_Kernel")}
 
   - file: "esphome-modular-lvgl-buttons/assets/fonts/Nunito-SemiBold.ttf"
     id: nunito_14
     size: 14
     bpp: 8
+    glyphsets: ${glyphsets | default("GF_Latin_Kernel")}
 
   - file: "esphome-modular-lvgl-buttons/assets/fonts/Nunito-SemiBold.ttf"
     id: nunito_12
     size: 12
     bpp: 8
+    glyphsets: ${glyphsets | default("GF_Latin_Kernel")}

--- a/common/theme/fonts.yaml
+++ b/common/theme/fonts.yaml
@@ -1,5 +1,5 @@
 ---
-# To support additional glyphs you can define the glyphsets-subsitution
+# To support additional glyphs you can define the glyphsets-substitution
 # in your main .yaml-file
 #
 # See also: https://esphome.io/components/font/#configuration-variables


### PR DESCRIPTION
By default, the fonts-file currently uses the ```GF_Latin_Kernel``` glyphsets, which support mainly english-only languages. This small update introduces a substitution to define the desired glyphsets in a central way. For instance, you can enable support for german umlauts or french accents by defining

```
substitutions:
  # [...]
  glyphsets: "GF_Latin_Core"
```