### PR TITLE
Added back support to specify fonts for sensor button

### DIFF
--- a/ui/sensor/README.md
+++ b/ui/sensor/README.md
@@ -28,6 +28,8 @@ The tile shows the icon top-left, the sensor name bottom-left, and the formatted
 | `row_span` | — | Number of rows to span (default: `1`) |
 | `column_span` | — | Number of columns to span (default: `1`) |
 | `page_id` | — | Parent page ID to place the tile on (default: `main_page`) |
+| `sensor_font` | - | Font for the sensor value, e.g. `nunito_36` |
+| `label_font` | - | Font for the sensor value, e.g. `nunito_36` |
 
 ## Usage
 

--- a/ui/sensor/README.md
+++ b/ui/sensor/README.md
@@ -28,8 +28,8 @@ The tile shows the icon top-left, the sensor name bottom-left, and the formatted
 | `row_span` | — | Number of rows to span (default: `1`) |
 | `column_span` | — | Number of columns to span (default: `1`) |
 | `page_id` | — | Parent page ID to place the tile on (default: `main_page`) |
-| `sensor_font` | - | Font for the sensor value, e.g. `nunito_36` |
-| `label_font` | - | Font for the sensor value, e.g. `nunito_36` |
+| `sensor_font` | — | Font for the sensor value, e.g. `nunito_36` |
+| `label_font` | — | Font for the label text, e.g. `nunito_36` |
 
 ## Usage
 

--- a/ui/sensor/local.yaml
+++ b/ui/sensor/local.yaml
@@ -14,6 +14,8 @@
 #   row_span:     (default: 1)
 #   column_span:  (default: 1)
 #   page_id:      parent page (default: main_page)
+#   label_font:   font for the label
+#   sensor_font:  font for the sensor value
 
 globals:
 - id: ${uid}_current_value
@@ -49,11 +51,12 @@ lvgl:
                 long_mode: wrap
                 width: 70%
                 text_color: $label_off_color
+                text_font: ${label_font | default(text_font)}
                 text: ${text}
             - label:
                 id: value_${uid}
                 align: top_right
-                text_font: $text_font
+                text_font: ${sensor_font | default(text_font)}
                 text_color: $label_on_color
                 text: "--"
 

--- a/ui/sensor/remote.yaml
+++ b/ui/sensor/remote.yaml
@@ -14,6 +14,8 @@
 #   row_span:     (default: 1)
 #   column_span:  (default: 1)
 #   page_id:      parent page (default: main_page)
+#   label_font:   font for the label
+#   sensor_font:  font for the sensor value
 
 globals:
 - id: ${uid}_current_value
@@ -49,10 +51,12 @@ lvgl:
                 long_mode: wrap
                 width: 70%
                 text_color: $label_off_color
+                text_font: ${label_font | default(text_font)}
                 text: ${text}
             - label:
                 id: value_${uid}
                 align: top_right
+                text_font: ${sensor_font | default(text_font)}
                 text_font: $text_font
                 text_color: $label_on_color
                 text: "--"

--- a/ui/sensor/remote.yaml
+++ b/ui/sensor/remote.yaml
@@ -57,7 +57,6 @@ lvgl:
                 id: value_${uid}
                 align: top_right
                 text_font: ${sensor_font | default(text_font)}
-                text_font: $text_font
                 text_color: $label_on_color
                 text: "--"
 


### PR DESCRIPTION
Previously, it has been possible to specify the fonts for the sensor button. This way, one could easily customize these buttons. The major rework done in #76 introduces a new architecture and a slightly new design. The rework however seems to have forgotten the options for the label and sensor font. This pull request reintroduces these variables with a default fallback value.