### PR TITLE
Added page support for page_button

### DIFF
--- a/ui/page/page_button.yaml
+++ b/ui/page/page_button.yaml
@@ -1,18 +1,22 @@
 ---
 # Change page button
-#    uid:
-#    row:
-#    column:
-#    row_span:
-#    column_span:
-#    text:
-#    icon:
-#    click_page:
+# Short click opens page_id page
+#
+# vars:
+#   uid:          unique identifier
+#   row:          grid row
+#   column:       grid column
+#   text:         tile label
+#   icon:         icon glyph (required — e.g. $mdi_page_next or $mdi_page_previous)
+#   row_span:     (default: 1)
+#   column_span:  (default: 1)
+#   page_id:      parent page (default: main_page)
+#   click_page:   destination page name (default: main_page)
 
-# This section adds a button to LVGL page main_page
+# This section adds a button to an LVGL page
 lvgl:
   pages:
-    - id: !extend main_page
+    - id: !extend ${page_id | default("main_page")}
       widgets:
         - container:
             id: ${uid}


### PR DESCRIPTION
Added support for page_button to be used on other pages. Eg. a "back" button to return to main_page

Fixed up the description and variables in the headers for consistency with other button templates.