### PR TITLE
Sensor and text sensor bg_opa

### DIFF
--- a/ui/sensor/remote.yaml
+++ b/ui/sensor/remote.yaml
@@ -5,10 +5,12 @@
 # vars:
 #   uid:          unique identifier
 #   entity_id:    HA sensor entity, e.g. "sensor.outdoor_temperature"
+#   attribute:    HA attribute to display instead of state (optional, default: state)                                                                                     
 #   row:          grid row
 #   column:       grid column
 #   text:         sensor name shown on tile
 #   icon:         icon glyph
+#   bg_opa:       background opacity. 0%-100% or text TRANSP or COVER, for fully opaque (optional, default: COVER)
 #   unit:         unit string appended to value, e.g. "°C"  (optional, default "")
 #   precision:    decimal places                             (optional, default 1)
 #   row_span:     (default: 1)
@@ -36,6 +38,7 @@ lvgl:
         grid_cell_y_align: stretch
         widgets:
         - button:
+            bg_opa: ${bg_opa | default("COVER")}                          
             id: button_${uid}
             clickable: false
             widgets:
@@ -65,6 +68,7 @@ sensor:
 - platform: homeassistant
   id: ${uid}_ha_value
   entity_id: ${entity_id}
+  attribute: ${attribute | default("")}                                       
   internal: true
   on_value:
   - lambda: id(${uid}_current_value) = x;

--- a/ui/text_sensor/remote.yaml
+++ b/ui/text_sensor/remote.yaml
@@ -10,6 +10,7 @@
 #   column:       grid column
 #   text:         sensor name shown on tile
 #   icon:         icon glyph
+#   bg_opa:       background opacity. 0%-100% or text TRANSP or COVER, for fully opaque (optional, default: COVER)
 #   row_span:     (default: 1)
 #   column_span:  (default: 1)
 #   page_id:      parent page (default: main_page)
@@ -33,6 +34,7 @@ lvgl:
         grid_cell_y_align: stretch
         widgets:
         - button:
+            bg_opa: ${bg_opa | default("COVER")}
             id: button_${uid}
             clickable: false
             widgets:


### PR DESCRIPTION
bg_opa (background opacity) var added to "sensor" and "text_sensor" tiles.

(Refer to LVGL docs for accepted values: https://esphome.io/components/lvgl/#lvgl-opacity)

I prefer to have a completely black background for these tiles, as they are not clickable and this difference makes it more intuitive. However, I've made the var optional and the default is 100% opacity, so no change if it is omitted.

I added support for "sensor" type tile to use a sensor attribute. For example, in my Home Assistant instance, current temperature outside is obtained from "weather.home" entity's "temperature" attribute. Default is entity state, as before.