### PR TITLE
feat(light): auto-return from detail page after configurable inactivity timeout

### DIFF
--- a/ui/light/detail.yaml
+++ b/ui/light/detail.yaml
@@ -146,9 +146,9 @@ lvgl:
             - globals.set:
                 id: ${uid}_current_brightness
                 value: !lambda return x / 255.0f;
-            - script.execute: ${uid}_reset_page_timeout
             - script.execute: ${uid}_update_bulb_color
             on_release:
+            - script.execute: ${uid}_reset_page_timeout
             - script.execute: ${uid}_light_set_brightness
         - label:
             align: bottom_mid
@@ -187,9 +187,9 @@ lvgl:
             - globals.set:
                 id: ${uid}_current_saturation
                 value: !lambda return x;
-            - script.execute: ${uid}_reset_page_timeout
             - script.execute: ${uid}_update_bulb_color
             on_release:
+            - script.execute: ${uid}_reset_page_timeout
             - script.execute: ${uid}_light_apply_hs
         - label:
             align: bottom_mid
@@ -349,9 +349,9 @@ lvgl:
                 - globals.set:
                     id: ${uid}_current_hue
                     value: !lambda return x;
-                - script.execute: ${uid}_reset_page_timeout
                 - script.execute: ${uid}_update_bulb_color
                 on_release:
+                - script.execute: ${uid}_reset_page_timeout
                 - script.execute: ${uid}_light_apply_hs
 
             # COLOR TEMP ARC
@@ -385,9 +385,9 @@ lvgl:
                 - globals.set:
                     id: ${uid}_current_color_temp
                     value: !lambda return x;
-                - script.execute: ${uid}_reset_page_timeout
                 - script.execute: ${uid}_update_bulb_color
                 on_release:
+                - script.execute: ${uid}_reset_page_timeout
                 - script.execute: ${uid}_light_apply_color_temp
 
     # LIGHTBULB TOGGLE BUTTON

--- a/ui/light/detail.yaml
+++ b/ui/light/detail.yaml
@@ -7,8 +7,11 @@
 #   uid:                  must match the including button's uid
 #   text:                 light name shown on the detail page header
 #   page_id:              parent page to return to (default: main_page)
-#   auto_return_seconds:  seconds of inactivity before auto-return to parent
-#                         page (default: 120, set to 0 to disable)
+#   auto_return_minutes:  minutes of inactivity before auto-return to parent
+#                         page (default: 2, set to 0 to disable). Resolution
+#                         is 1 minute because this hooks into the library's
+#                         once-per-minute time_update script ("screen_cron")
+#                         instead of running its own per-second interval.
 #
 # Scripts the button MUST define:
 #   ${uid}_light_toggle           — toggle the light on/off
@@ -65,8 +68,9 @@ globals:
 
 # Page timeout tracking for auto-return to parent page after inactivity.
 # Counter doubles as an open/closed flag (>0 means detail page is open) and
-# the elapsed-seconds counter. The configured timeout comes from the
-# `auto_return_seconds` package var (default 120, set 0 to disable).
+# the elapsed-minutes counter ticked by the library's time_update script.
+# The configured timeout comes from the `auto_return_minutes` package var
+# (default 2, set 0 to disable).
 - id: ${uid}_page_inactivity_counter
   type: int
   initial_value: '0'
@@ -459,9 +463,43 @@ lvgl:
 
 script:
 # ═══════════════════════════════════════════════════════════════════════════════
-# Reset page inactivity counter (resets 2-minute auto-return timer)
-# Call on page open and on every user interaction to restart the timer
-# ═══════════════════════════════════════════════════════════════════════════════
+# Auto-return tick — hooks into the library's once-per-minute time_update
+# script. While the counter is > 0 (i.e. the detail page is open), increment
+# it on every minute tick; when it reaches `auto_return_minutes`, navigate
+# back to the parent page and reset. Set `auto_return_minutes: 0` to disable.
+#
+# Using !extend time_update means we do not add a per-light interval timer —
+# all time-related work for this device runs on a single shared cadence.
+# ═══════════════════════════════════════════════════════════════════════════
+- id: !extend time_update
+  then:
+  - if:
+      condition:
+        lambda: |-
+          return ${auto_return_minutes | default(2)} > 0 &&
+                 id(${uid}_page_inactivity_counter) > 0;
+      then:
+      - if:
+          condition:
+            lambda: |-
+              return id(${uid}_page_inactivity_counter) >= ${auto_return_minutes | default(2)};
+          then:
+          - lvgl.page.show:
+              id: ${page_id | default("main_page")}
+              animation: MOVE_RIGHT
+              time: 300ms
+          - globals.set:
+              id: ${uid}_page_inactivity_counter
+              value: '0'
+          else:
+          - globals.set:
+              id: ${uid}_page_inactivity_counter
+              value: !lambda 'return id(${uid}_page_inactivity_counter) + 1;'
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Reset page inactivity counter (resets the auto-return timer)
+# Call on page open and on every user interaction to restart the timer.
+# ═══════════════════════════════════════════════════════════════════════════
 - id: ${uid}_reset_page_timeout
   then:
   - globals.set:
@@ -667,36 +705,3 @@ script:
       lv_obj_set_style_shadow_width(id(${uid}_bulb_btn), width, 0);
       lv_obj_set_style_text_color(id(${uid}_bulb_icon), lv_color_hex(color), 0);
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Auto-return to parent page after inactivity timeout
-# Per-light 1s interval that runs only while the detail page is open
-# (counter > 0). When the counter passes ${auto_return_seconds} (default 120,
-# 0 disables the feature entirely), navigate back to the parent page and reset.
-# ═══════════════════════════════════════════════════════════════════════════════
-interval:
-- interval: 1s
-  then:
-  # Skip entirely when feature is disabled (auto_return_seconds = 0)
-  # OR when the detail page is not open (counter == 0).
-  - if:
-      condition:
-        lambda: |-
-          return ${auto_return_seconds | default(120)} > 0 &&
-                 id(${uid}_page_inactivity_counter) > 0;
-      then:
-      - if:
-          condition:
-            lambda: |-
-              return id(${uid}_page_inactivity_counter) >= ${auto_return_seconds | default(120)};
-          then:
-          - lvgl.page.show:
-              id: ${page_id | default("main_page")}
-              animation: MOVE_RIGHT
-              time: 300ms
-          - globals.set:
-              id: ${uid}_page_inactivity_counter
-              value: '0'
-          else:
-          - globals.set:
-              id: ${uid}_page_inactivity_counter
-              value: !lambda 'return id(${uid}_page_inactivity_counter) + 1;'

--- a/ui/light/detail.yaml
+++ b/ui/light/detail.yaml
@@ -4,9 +4,11 @@
 # Works identically for both local ESPHome lights and remote HA lights.
 #
 # vars:
-#   uid:      must match the including button's uid
-#   text:     light name shown on the detail page header
-#   page_id:  parent page to return to (default: main_page)
+#   uid:                  must match the including button's uid
+#   text:                 light name shown on the detail page header
+#   page_id:              parent page to return to (default: main_page)
+#   auto_return_seconds:  seconds of inactivity before auto-return to parent
+#                         page (default: 120, set to 0 to disable)
 #
 # Scripts the button MUST define:
 #   ${uid}_light_toggle           — toggle the light on/off
@@ -60,6 +62,12 @@ globals:
 - id: ${uid}_is_on
   type: bool
   initial_value: 'false'
+
+# Page timeout tracking for auto-return after 2 minutes of inactivity
+- id: ${uid}_page_inactivity_counter
+  type: int
+  initial_value: '0'
+  restore_value: false
 
 lvgl:
   gradients:
@@ -135,6 +143,7 @@ lvgl:
             - globals.set:
                 id: ${uid}_current_brightness
                 value: !lambda return x / 255.0f;
+            - script.execute: ${uid}_reset_page_timeout
             - script.execute: ${uid}_update_bulb_color
             on_release:
             - script.execute: ${uid}_light_set_brightness
@@ -175,6 +184,7 @@ lvgl:
             - globals.set:
                 id: ${uid}_current_saturation
                 value: !lambda return x;
+            - script.execute: ${uid}_reset_page_timeout
             - script.execute: ${uid}_update_bulb_color
             on_release:
             - script.execute: ${uid}_light_apply_hs
@@ -336,6 +346,7 @@ lvgl:
                 - globals.set:
                     id: ${uid}_current_hue
                     value: !lambda return x;
+                - script.execute: ${uid}_reset_page_timeout
                 - script.execute: ${uid}_update_bulb_color
                 on_release:
                 - script.execute: ${uid}_light_apply_hs
@@ -371,6 +382,7 @@ lvgl:
                 - globals.set:
                     id: ${uid}_current_color_temp
                     value: !lambda return x;
+                - script.execute: ${uid}_reset_page_timeout
                 - script.execute: ${uid}_update_bulb_color
                 on_release:
                 - script.execute: ${uid}_light_apply_color_temp
@@ -391,6 +403,7 @@ lvgl:
         border_width: 0
         radius: 50
         on_short_click:
+        - script.execute: ${uid}_reset_page_timeout
         - script.execute: ${uid}_light_toggle
         widgets:
         - label:
@@ -433,12 +446,25 @@ lvgl:
             text_color: steel_blue
             text: $mdi_chevron_up
         on_click:
+        - globals.set:
+            id: ${uid}_page_inactivity_counter
+            value: '0'
         - lvgl.page.show:
             id: ${page_id | default("main_page")}
             animation: MOVE_RIGHT
             time: 300ms
 
 script:
+# ═══════════════════════════════════════════════════════════════════════════════
+# Reset page inactivity counter (resets 2-minute auto-return timer)
+# Call on page open and on every user interaction to restart the timer
+# ═══════════════════════════════════════════════════════════════════════════════
+- id: ${uid}_reset_page_timeout
+  then:
+  - globals.set:
+      id: ${uid}_page_inactivity_counter
+      value: '1'
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Sync globals → LVGL widgets (called after any state change)
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -637,3 +663,34 @@ script:
       lv_obj_set_style_shadow_spread(id(${uid}_bulb_btn), spread, 0);
       lv_obj_set_style_shadow_width(id(${uid}_bulb_btn), width, 0);
       lv_obj_set_style_text_color(id(${uid}_bulb_icon), lv_color_hex(color), 0);
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Auto-return to parent page after inactivity timeout
+# Per-light 1s interval that increments the counter while > 0 (i.e. page open).
+# When the counter reaches ${auto_return_seconds} (default 120, 0 disables),
+# navigate back to the parent page and reset.
+# ═══════════════════════════════════════════════════════════════════════════════
+interval:
+- interval: 1s
+  then:
+  - if:
+      condition:
+        lambda: 'return id(${uid}_page_inactivity_counter) > 0;'
+      then:
+      - if:
+          condition:
+            lambda: |-
+              return ${auto_return_seconds | default(120)} > 0 &&
+                     id(${uid}_page_inactivity_counter) >= ${auto_return_seconds | default(120)};
+          then:
+          - lvgl.page.show:
+              id: ${page_id | default("main_page")}
+              animation: MOVE_RIGHT
+              time: 300ms
+          - globals.set:
+              id: ${uid}_page_inactivity_counter
+              value: '0'
+          else:
+          - globals.set:
+              id: ${uid}_page_inactivity_counter
+              value: !lambda 'return id(${uid}_page_inactivity_counter) + 1;'

--- a/ui/light/detail.yaml
+++ b/ui/light/detail.yaml
@@ -63,7 +63,10 @@ globals:
   type: bool
   initial_value: 'false'
 
-# Page timeout tracking for auto-return after 2 minutes of inactivity
+# Page timeout tracking for auto-return to parent page after inactivity.
+# Counter doubles as an open/closed flag (>0 means detail page is open) and
+# the elapsed-seconds counter. The configured timeout comes from the
+# `auto_return_seconds` package var (default 120, set 0 to disable).
 - id: ${uid}_page_inactivity_counter
   type: int
   initial_value: '0'
@@ -666,22 +669,25 @@ script:
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Auto-return to parent page after inactivity timeout
-# Per-light 1s interval that increments the counter while > 0 (i.e. page open).
-# When the counter reaches ${auto_return_seconds} (default 120, 0 disables),
-# navigate back to the parent page and reset.
+# Per-light 1s interval that runs only while the detail page is open
+# (counter > 0). When the counter passes ${auto_return_seconds} (default 120,
+# 0 disables the feature entirely), navigate back to the parent page and reset.
 # ═══════════════════════════════════════════════════════════════════════════════
 interval:
 - interval: 1s
   then:
+  # Skip entirely when feature is disabled (auto_return_seconds = 0)
+  # OR when the detail page is not open (counter == 0).
   - if:
       condition:
-        lambda: 'return id(${uid}_page_inactivity_counter) > 0;'
+        lambda: |-
+          return ${auto_return_seconds | default(120)} > 0 &&
+                 id(${uid}_page_inactivity_counter) > 0;
       then:
       - if:
           condition:
             lambda: |-
-              return ${auto_return_seconds | default(120)} > 0 &&
-                     id(${uid}_page_inactivity_counter) >= ${auto_return_seconds | default(120)};
+              return id(${uid}_page_inactivity_counter) >= ${auto_return_seconds | default(120)};
           then:
           - lvgl.page.show:
               id: ${page_id | default("main_page")}

--- a/ui/light/local.yaml
+++ b/ui/light/local.yaml
@@ -11,7 +11,9 @@
 #   icon:         icon glyph (optional, default: $mdi_lightbulb)
 #   row_span:     (default: 1)
 #   column_span:  (default: 1)
-#   page_id:      parent page (default: main_page)
+#   page_id:             parent page (default: main_page)
+#   auto_return_seconds: detail-page inactivity timeout in seconds
+#                        (default: 120, set to 0 to disable)
 
 packages:
   ${uid}_detail: !include
@@ -20,6 +22,7 @@ packages:
       uid: ${uid}
       text: ${text}
       page_id: ${page_id | default("main_page")}
+      auto_return_seconds: ${auto_return_seconds | default(120)}
 
 lvgl:
   pages:

--- a/ui/light/local.yaml
+++ b/ui/light/local.yaml
@@ -79,6 +79,7 @@ lvgl:
                   id: ${uid}_light_page
                   animation: MOVE_LEFT
                   time: 300ms
+              - script.execute: ${uid}_reset_page_timeout
 
 # ── Hook into the light's state changes ───────────────────────────────────────
 light:

--- a/ui/light/local.yaml
+++ b/ui/light/local.yaml
@@ -12,8 +12,8 @@
 #   row_span:     (default: 1)
 #   column_span:  (default: 1)
 #   page_id:             parent page (default: main_page)
-#   auto_return_seconds: detail-page inactivity timeout in seconds
-#                        (default: 120, set to 0 to disable)
+#   auto_return_minutes: detail-page inactivity timeout in minutes
+#                        (default: 2, set to 0 to disable)
 
 packages:
   ${uid}_detail: !include
@@ -22,7 +22,7 @@ packages:
       uid: ${uid}
       text: ${text}
       page_id: ${page_id | default("main_page")}
-      auto_return_seconds: ${auto_return_seconds | default(120)}
+      auto_return_minutes: ${auto_return_minutes | default(2)}
 
 lvgl:
   pages:

--- a/ui/light/remote.yaml
+++ b/ui/light/remote.yaml
@@ -11,7 +11,9 @@
 #   icon:         icon glyph (optional, default: $mdi_lightbulb)
 #   row_span:     (default: 1)
 #   column_span:  (default: 1)
-#   page_id:      parent page (default: main_page)
+#   page_id:             parent page (default: main_page)
+#   auto_return_seconds: detail-page inactivity timeout in seconds
+#                        (default: 120, set to 0 to disable)
 
 packages:
   ${uid}_detail: !include
@@ -20,6 +22,7 @@ packages:
       uid: ${uid}
       text: ${text}
       page_id: ${page_id | default("main_page")}
+      auto_return_seconds: ${auto_return_seconds | default(120)}
 
 lvgl:
   pages:

--- a/ui/light/remote.yaml
+++ b/ui/light/remote.yaml
@@ -79,6 +79,7 @@ lvgl:
                   id: ${uid}_light_page
                   animation: MOVE_LEFT
                   time: 300ms
+              - script.execute: ${uid}_reset_page_timeout
 
 # ── HA state sensors ──────────────────────────────────────────────────────────
 

--- a/ui/light/remote.yaml
+++ b/ui/light/remote.yaml
@@ -12,8 +12,8 @@
 #   row_span:     (default: 1)
 #   column_span:  (default: 1)
 #   page_id:             parent page (default: main_page)
-#   auto_return_seconds: detail-page inactivity timeout in seconds
-#                        (default: 120, set to 0 to disable)
+#   auto_return_minutes: detail-page inactivity timeout in minutes
+#                        (default: 2, set to 0 to disable)
 
 packages:
   ${uid}_detail: !include
@@ -22,7 +22,7 @@ packages:
       uid: ${uid}
       text: ${text}
       page_id: ${page_id | default("main_page")}
-      auto_return_seconds: ${auto_return_seconds | default(120)}
+      auto_return_minutes: ${auto_return_minutes | default(2)}
 
 lvgl:
   pages:


### PR DESCRIPTION
Adds an opt-in inactivity timeout to the light detail page so it auto-returns to its parent page after N seconds of no user interaction.

## Behavior

- New `auto_return_seconds` package var on `ui/light/detail.yaml` (default `120`; set to `0` to disable entirely).
- Per-light global `\_page_inactivity_counter` doubles as an open/closed flag and the elapsed-seconds counter.
- A 1s `interval` block (a) short-circuits when the feature is disabled or the detail page is closed, and (b) navigates back to `\` when the counter reaches the configured timeout.
- Reset script `\_reset_page_timeout` is called from each user-driven release/click on the detail page widgets:
  - brightness slider `on_release`
  - saturation slider `on_release`
  - hue arc `on_release`
  - color-temp arc `on_release`
  - bulb toggle `on_short_click`
- Close (back) button explicitly resets the counter to `0` so the timer doesn't keep running after manual exit.

## Why `on_release` and not `on_value`

Initially I wired the slider/arc resets to `on_value`, but Home Assistant pushes state updates back to ESPHome programmatically while a light is changing, which fires `on_value` continuously and reset the inactivity timer forever. Switching to `on_release` ensures only genuine user touch-release events reset the timer.

## Background

This was originally opened against iezhkv/esphome-modular-lvgl-buttons#1 (closed); re-targeted here against the active upstream. Includes Copilot reviewer feedback already addressed (var forwarding, short-circuit when disabled, off-by-one fix, stale comment cleanup, lambda format-arg cast).