### PR TITLE
feat(ui/clock): expose flip_clock hour/minute panel IDs

### DIFF
--- a/ui/clock/flip_clock.yaml
+++ b/ui/clock/flip_clock.yaml
@@ -92,6 +92,7 @@ lvgl:
                   widgets:
                     # ── Hour Panel ──
                     - obj:
+                        id: flip_hour_panel
                         styles: flip_panel_style
                         flex_grow: 1
                         scrollable: false
@@ -123,6 +124,7 @@ lvgl:
 
                     # ── Minute Panel ──
                     - obj:
+                        id: flip_min_panel
                         styles: flip_panel_style
                         flex_grow: 1
                         scrollable: false


### PR DESCRIPTION
Adds `id: flip_hour_panel` and `id: flip_min_panel` to the two panel `obj` widgets in `ui/clock/flip_clock.yaml`.

## Why

Downstream screen configs can't currently reach the two panel containers to do things like change the panel `bg_color` at runtime. A common use case is colour-coding the clock face based on an external condition \u2014 in our setup we tint both panels light red when the Enphase Enpower reports an off-grid event, so the clock visually flags the outage at a glance.

Without these IDs the only options are forking the whole package or reaching into the internal LVGL tree by index (fragile).

## What changes

Two new `id:` lines, nothing else. Naming matches the existing `flip_*_label` convention already used in the same file (`flip_hour_label`, `flip_min_label`, `flip_am_label`, `flip_pm_label`).

## Compatibility

Zero behaviour change. All existing widgets, styles, layout and labels untouched. Existing configs continue to work without modification.