### PR TITLE
feat(ui/voice): add voice indicator pill widget package

### DIFF
--- a/ui/voice/indicator_pill.yaml
+++ b/ui/voice/indicator_pill.yaml
@@ -1,0 +1,119 @@
+---
+# Voice Indicator Pill
+#
+# A compact pill-shaped status widget that reflects the current state of the
+# Home Assistant voice pipeline running on this device. Designed to live in a
+# single grid cell on the main page (typically next to a volume button on the
+# bottom row of an audio screen).
+#
+# State colour map (driven by the HA voice pipeline status text_sensor):
+#   - Idle / wake-word running -> dark navy   (label "Tap to talk" / "Idle")
+#   - HA pipeline listening    -> dark blue   (label "Listening")
+#
+# Downstream configs can drive additional states by writing to the pill
+# directly, e.g.:
+#   - lvgl.label.update:  { id: voice_indicator_label, text: "Heard!" }
+#   - lvgl.widget.update:
+#       id: voice_indicator
+#       bg_color: 0x1B5E20
+#       border_color: 0x69F0AE
+#
+# Tap the pill to manually start the voice assistant (useful when wake word is
+# unreliable). The pill briefly shows "Talk now" then returns to "Tap to talk"
+# after 10 s.
+#
+# vars:
+#   uid:               unique identifier (default: voice_indicator)
+#   page_id:           parent page (default: main_page)
+#   row:               grid row position (REQUIRED)
+#   column:            grid column position (REQUIRED)
+#   row_span:          (default: 1)
+#   column_span:       (default: 1)
+#   width:             pill width in px  (default: 100)
+#   height:            pill height in px (default: 40)
+#   voice_status_entity_id:
+#                      HA text_sensor entity_id that carries the voice pipeline
+#                      state (typically "sensor.<device_name>_voice_assistant_status")
+#                      REQUIRED.
+#
+# Optional theme overrides (any can be omitted to use the defaults shown):
+#   idle_bg_color:        (default: 0x222244)
+#   idle_border_color:    (default: 0x444466)
+#   idle_text_color:      (default: 0x666677)
+#   listening_bg_color:   (default: 0x1565C0)
+#   listening_border_color: (default: 0x90CAF9)
+
+globals:
+  # Suppresses on_click that LVGL fires after on_long_press release (used by
+  # downstream extensions such as a long-press wake-word disable toggle).
+  - id: ${uid | default("voice_indicator")}_long_press_guard
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+lvgl:
+  pages:
+  - id: !extend ${page_id | default("main_page")}
+    widgets:
+    - obj:
+        id: ${uid | default("voice_indicator")}
+        grid_cell_row_pos: ${row}
+        grid_cell_column_pos: ${column}
+        grid_cell_row_span: ${row_span | default(1)}
+        grid_cell_column_span: ${column_span | default(1)}
+        grid_cell_x_align: center
+        grid_cell_y_align: end
+        width: ${width | default(100)}
+        height: ${height | default(40)}
+        bg_color: ${idle_bg_color | default(0x222244)}
+        radius: 8
+        border_width: 1
+        border_color: ${idle_border_color | default(0x444466)}
+        clickable: true   # REQUIRED — obj does not receive clicks otherwise
+        on_click:
+          then:
+          - if:
+              condition:
+                lambda: 'return id(${uid | default("voice_indicator")}_long_press_guard);'
+              then:
+              - logger.log: "voice indicator on_click suppressed (long-press tail)"
+              else:
+              - micro_wake_word.stop:
+              - delay: 150ms
+              - voice_assistant.start:
+              - lvgl.label.update:
+                  id: ${uid | default("voice_indicator")}_label
+                  text: "Talk now"
+              - delay: 10s
+              - lvgl.label.update:
+                  id: ${uid | default("voice_indicator")}_label
+                  text: "Tap to talk"
+              - micro_wake_word.start:
+        widgets:
+        - label:
+            id: ${uid | default("voice_indicator")}_label
+            text: "Tap to talk"
+            text_font: $text_font
+            text_color: ${idle_text_color | default(0x666677)}
+            align: center
+
+text_sensor:
+  - platform: homeassistant
+    id: ${uid | default("voice_indicator")}_pipeline_state
+    entity_id: ${voice_status_entity_id}
+    on_value:
+      then:
+        - lambda: |-
+            if (x == "Listening") {
+              lv_label_set_text(id(${uid | default("voice_indicator")}_label), "Listening");
+              lv_obj_set_style_bg_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${listening_bg_color | default(0x1565C0)}), 0);
+              lv_obj_set_style_border_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${listening_border_color | default(0x90CAF9)}), 0);
+            } else {
+              lv_label_set_text(id(${uid | default("voice_indicator")}_label), "Idle");
+              lv_obj_set_style_bg_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${idle_bg_color | default(0x222244)}), 0);
+              lv_obj_set_style_border_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${idle_border_color | default(0x444466)}), 0);
+            }


### PR DESCRIPTION
Adds `ui/voice/indicator_pill.yaml` — a compact pill-shaped LVGL status widget that reflects the Home Assistant voice pipeline state and lets the user tap it to manually start the voice assistant.

## Why

On audio-equipped touch panels (mic + speaker) it's useful to give the user direct feedback about what the voice pipeline is doing right now — and a tap target to start a conversation manually when the wake word doesn't fire reliably. Today this requires hand-rolling a fairly elaborate LVGL `obj`, a `text_sensor` HA bridge, a per-state `lambda`, and a click handler in every screen YAML. Bundling it into one package removes that boilerplate and gives every audio screen the same look/behaviour.

## What's in the package

- **One LVGL `obj` (the pill)** placed in a configurable grid cell, default 100×40 px, idle navy theme.
- **One global** (`${uid}_long_press_guard`, used to suppress the LVGL on_click that fires after a long-press release — important for downstream extensions such as a long-press wake-word disable toggle).
- **One `text_sensor: platform: homeassistant`** subscribing to the voice pipeline status entity. `on_value` lambda updates the pill colour + label between Idle and Listening.
- **on_click handler** on the pill: stops the wake word, starts `voice_assistant`, shows "Talk now" for 10 s, then restores "Tap to talk" and restarts the wake word.

## Configurable vars

| Var | Required | Default | Purpose |
|---|---|---|---|
| `uid` | no | `voice_indicator` | unique identifier (also names the inner label widget `${uid}_label`) |
| `page_id` | no | `main_page` | parent page |
| `row`, `column` | yes | — | grid cell |
| `row_span`, `column_span` | no | `1` | grid spans |
| `width`, `height` | no | 100, 40 | pill dimensions |
| `voice_status_entity_id` | yes | — | HA text_sensor entity, e.g. `sensor.<device_name>_voice_assistant_status` |
| `idle_bg_color`, `idle_border_color`, `idle_text_color` | no | navy palette | theme overrides |
| `listening_bg_color`, `listening_border_color` | no | blue palette | theme overrides |

## Compatibility

- Requires the device to already be using `hardware/media_player-voice_assistant.yaml` (so `micro_wake_word` and `voice_assistant` components exist).
- Self-contained otherwise: declares its own globals, text_sensor and LVGL widgets; no main-yaml plumbing required.
- Downstream configs can drive additional pill states (e.g. green "Heard!" flash on wake-word detection, or a "Wake OFF" indication when the user has temporarily disabled wake word) by writing to the documented widget IDs.

## Future work

A follow-up PR could move the green "Heard!" flash from the user's screen YAML into `hardware/media_player-voice_assistant.yaml` (calling `lvgl.label.update` against `${uid}_label` directly), so screens that include this package get that state for free.
