### PR TITLE
feat(ui/audio): add volume button + popup overlay package

### DIFF
--- a/ui/audio/volume_button.yaml
+++ b/ui/audio/volume_button.yaml
@@ -1,0 +1,131 @@
+---
+# Volume Button + Popup Overlay
+#
+# A tile-shaped button that opens a full-screen volume slider popup. The popup
+# auto-closes after `autoclose_seconds` of inactivity (default 15 s) and binds
+# directly to the speaker via `media_player.volume_set` on the configured
+# media_player id.
+#
+# vars:
+#   uid:                  unique identifier (default: volume_btn)
+#   page_id:              parent page (default: main_page)
+#   row:                  grid row position    (REQUIRED)
+#   column:               grid column position (REQUIRED)
+#   row_span:             (default: 1)
+#   column_span:          (default: 1)
+#   width:                button width  (default: 100)
+#   height:               button height (default: 40)
+#   text:                 button label  (default: "Volume")
+#   icon:                 button icon glyph (default: $mdi_volume_high)
+#   media_player_id:      ESPHome media_player component id to control
+#                         (default: my_media_player — as defined by
+#                         hardware/media_player-voice_assistant.yaml)
+#   autoclose_seconds:    popup inactivity timeout (default: 15)
+#   initial_value:        slider initial value 0-100 (default: 75)
+
+script:
+  # Restart-mode timer: every interaction reschedules the auto-close.
+  - id: ${uid | default("volume_btn")}_popup_autoclose
+    mode: restart
+    then:
+      - delay: ${autoclose_seconds | default(15)}s
+      - lvgl.widget.update:
+          id: ${uid | default("volume_btn")}_popup
+          hidden: true
+
+lvgl:
+  pages:
+  - id: !extend ${page_id | default("main_page")}
+    widgets:
+    - button:
+        id: ${uid | default("volume_btn")}
+        grid_cell_row_pos: ${row}
+        grid_cell_column_pos: ${column}
+        grid_cell_row_span: ${row_span | default(1)}
+        grid_cell_column_span: ${column_span | default(1)}
+        grid_cell_x_align: center
+        grid_cell_y_align: end
+        width: ${width | default(100)}
+        height: ${height | default(40)}
+        bg_color: 0x222244
+        radius: 8
+        border_width: 1
+        border_color: 0x5555AA
+        on_click:
+          then:
+            - lvgl.widget.update:
+                id: ${uid | default("volume_btn")}_popup
+                hidden: false
+            - script.execute: ${uid | default("volume_btn")}_popup_autoclose
+        widgets:
+          - label:
+              text: ${icon | default("$mdi_volume_high")}
+              text_font: $icon_font
+              text_color: white
+              align: top_mid
+          - label:
+              text: ${text | default("Volume")}
+              text_font: $text_font
+              text_color: 0xCCCCCC
+              align: bottom_mid
+
+  top_layer:
+    widgets:
+      - obj:
+          id: ${uid | default("volume_btn")}_popup
+          width: 460
+          height: 320
+          align: center
+          bg_color: 0x222233
+          bg_opa: COVER
+          radius: 16
+          border_width: 2
+          border_color: 0x5555AA
+          pad_all: 24
+          hidden: true
+          widgets:
+            - label:
+                text: "Speaker Volume"
+                text_color: white
+                align: top_mid
+            - label:
+                id: ${uid | default("volume_btn")}_value_label
+                text: "${initial_value | default(75)}%"
+                text_color: 0x90CAF9
+                align: center
+                y: -30
+            - slider:
+                id: ${uid | default("volume_btn")}_slider
+                width: 380
+                height: 28
+                align: center
+                y: 20
+                min_value: 0
+                max_value: 100
+                value: ${initial_value | default(75)}
+                on_value:
+                  - lvgl.label.update:
+                      id: ${uid | default("volume_btn")}_value_label
+                      text: !lambda 'return (std::to_string((int)x) + "%").c_str();'
+                  - media_player.volume_set:
+                      id: ${media_player_id | default("my_media_player")}
+                      volume: !lambda 'return x / 100.0f;'
+                  - script.execute: ${uid | default("volume_btn")}_popup_autoclose
+            - button:
+                width: 140
+                height: 50
+                align: bottom_mid
+                y: -10
+                bg_color: 0x333344
+                radius: 10
+                on_click:
+                  then:
+                    - script.stop: ${uid | default("volume_btn")}_popup_autoclose
+                    - lvgl.widget.update:
+                        id: ${uid | default("volume_btn")}_popup
+                        hidden: true
+                widgets:
+                  - label:
+                      text: "Close"
+                      text_color: 0xAAAAAA
+                      align: center


### PR DESCRIPTION
Adds `ui/audio/volume_button.yaml` — a tile-shaped button that opens a full-screen volume slider popup, bound directly to a configurable `media_player` id via `media_player.volume_set`.

## Why

On audio-equipped touch panels with a small fixed-grid main page, dedicating a full grid cell to a static volume slider is wasteful. The common pattern is a small "Volume" tile that opens a centred slider popup on tap, then auto-dismisses after a few seconds. Today this requires hand-rolling the tile button, the `top_layer` `obj` popup, the slider event handler that bridges to `media_player.volume_set`, and a restart-mode auto-close script in every screen YAML. Bundling all of that into one package removes the boilerplate and ensures consistent UX across screens.

## What's in the package

- **One LVGL `button`** placed in a configurable grid cell on the parent page (default 100×40 px, navy theme with `mdi_volume_high` icon and "Volume" label).
- **One `obj` popup** in `top_layer.widgets` (460×320 px, centred, modal-feeling). Contains:
  - A "Speaker Volume" header label
  - A live `${uid}_value_label` showing the current %
  - A `slider` (0–100) whose `on_value` updates the label, calls `media_player.volume_set` with `x / 100.0f`, and reschedules the auto-close
  - A "Close" button that stops the autoclose timer and hides the popup
- **One `script` (`${uid}_popup_autoclose`, mode: restart)** that hides the popup after `autoclose_seconds` of inactivity.

## Configurable vars

| Var | Required | Default | Purpose |
|---|---|---|---|
| `uid` | no | `volume_btn` | unique identifier (also names the popup `${uid}_popup`, slider `${uid}_slider`, label `${uid}_value_label`, autoclose script `${uid}_popup_autoclose`) |
| `page_id` | no | `main_page` | parent page |
| `row`, `column` | yes | — | grid cell of the tile |
| `row_span`, `column_span` | no | `1` | grid spans |
| `width`, `height` | no | 100, 40 | tile dimensions |
| `text` | no | `Volume` | tile label |
| `icon` | no | `$mdi_volume_high` | tile icon glyph |
| `media_player_id` | no | `my_media_player` | ESPHome `media_player` id to control (the default matches `hardware/media_player-voice_assistant.yaml`) |
| `autoclose_seconds` | no | `15` | popup inactivity timeout |
| `initial_value` | no | `75` | slider initial value 0–100 |

## Compatibility

- Requires a `media_player` component with the configured id to already exist (typically pulled in via `hardware/media_player-voice_assistant.yaml`).
- Self-contained otherwise: declares its own `script`, tile button and `top_layer` popup; no main-yaml plumbing required.
- Multiple instances on one device are supported via distinct `uid` values (every internal id is namespaced by `${uid}`).

## Pairs naturally with

- `ui/voice/indicator_pill.yaml` (PR #99) — same grid row, same look-and-feel, audio screens typically want both.
