### PR TITLE
feat(voice): wake-word user-disable + Heard/Wake-OFF pill states (stacked on #99)

### DIFF
--- a/hardware/media_player-voice_assistant.yaml
+++ b/hardware/media_player-voice_assistant.yaml
@@ -1,6 +1,40 @@
 ---
 # Media Player and voice assistant
 # Uses Sendspin for multiroom audio and speaker_source for improved media playback
+#
+# Wake-word user-disable
+# ----------------------
+# Declares a `wake_word_user_disabled` global. When set true (e.g. by a UI
+# long-press handler in a screen YAML), the three internal restarts of
+# `micro_wake_word` (media_player.on_idle, voice_assistant.on_end,
+# voice_assistant.on_client_connected) are skipped, so the wake word stays
+# off until the user re-enables it.
+#
+# The corresponding `micro_wake_word.stop` is *not* gated — stopping is always
+# safe and idempotent. Downstream UI that toggles the global is responsible
+# for calling stop/start once at toggle time.
+#
+# Heard! pill flash
+# -----------------
+# When `ui/voice/indicator_pill.yaml` is included on the same device, the
+# `on_wake_word_detected` action briefly flashes the pill green and writes
+# "Heard!" so the user gets immediate visual confirmation that the wake word
+# fired. The package's `text_sensor` will overwrite it with the next pipeline
+# state (typically blue "Listening") within a second or two.
+#
+# These updates target the default widget IDs declared by the pill package
+# (`voice_indicator` and `voice_indicator_label`). If the pill package is not
+# included, ESPHome's compile-time validator will flag the missing IDs — in
+# that case either include the pill package or remove the three lvgl.* lines
+# inside `on_wake_word_detected:` below.
+
+globals:
+  # Sticky user toggle that suppresses internal wake-word restarts.
+  # restore_value: true so the user's choice persists across reboots.
+  - id: wake_word_user_disabled
+    type: bool
+    restore_value: true
+    initial_value: 'false'
 
 external_components:
   - source:
@@ -111,7 +145,11 @@ media_player:
                       id: my_media_player
           then:
             - logger.log: "Media player idle, restarting wake word"
-            - micro_wake_word.start
+            - if:
+                condition:
+                  lambda: 'return !id(wake_word_user_disabled);'
+                then:
+                  - micro_wake_word.start:
 
 sensor:
   - platform: template
@@ -143,6 +181,15 @@ micro_wake_word:
   on_wake_word_detected:
     then:
       - logger.log: "Wake word detected"
+      # Brief green flash on the voice indicator pill (if `ui/voice/indicator_pill.yaml`
+      # is included on this device). Overwritten by the pipeline `text_sensor` shortly.
+      - lvgl.label.update:
+          id: voice_indicator_label
+          text: "Heard!"
+      - lvgl.widget.update:
+          id: voice_indicator
+          bg_color: 0x1B5E20
+          border_color: 0x69F0AE
       - voice_assistant.start:
           wake_word: !lambda return wake_word;
 
@@ -171,8 +218,16 @@ voice_assistant:
     # Brief pause to let the speaker fully release the I2S bus
     - delay: 300ms
     - logger.log: "Voice assistant ended, restarting wake word"
-    - micro_wake_word.start:
+    - if:
+        condition:
+          lambda: 'return !id(wake_word_user_disabled);'
+        then:
+          - micro_wake_word.start:
   on_client_connected:
-    - micro_wake_word.start:
+    - if:
+        condition:
+          lambda: 'return !id(wake_word_user_disabled);'
+        then:
+          - micro_wake_word.start:
   on_client_disconnected:
     - micro_wake_word.stop:

--- a/ui/voice/indicator_pill.yaml
+++ b/ui/voice/indicator_pill.yaml
@@ -6,21 +6,20 @@
 # single grid cell on the main page (typically next to a volume button on the
 # bottom row of an audio screen).
 #
-# State colour map (driven by the HA voice pipeline status text_sensor):
+# State colour map (driven by the HA voice pipeline status text_sensor and
+# the `wake_word_user_disabled` global declared by
+# `hardware/media_player-voice_assistant.yaml`):
 #   - Idle / wake-word running -> dark navy   (label "Tap to talk" / "Idle")
+#   - Wake word detected       -> dark green  (label "Heard!")  — set inside the
+#                                 hardware package on `on_wake_word_detected`
 #   - HA pipeline listening    -> dark blue   (label "Listening")
+#   - User disabled wake word  -> dark red    (label "Wake OFF") — sticky;
+#                                 long-press the pill to toggle
 #
-# Downstream configs can drive additional states by writing to the pill
-# directly, e.g.:
-#   - lvgl.label.update:  { id: voice_indicator_label, text: "Heard!" }
-#   - lvgl.widget.update:
-#       id: voice_indicator
-#       bg_color: 0x1B5E20
-#       border_color: 0x69F0AE
-#
-# Tap the pill to manually start the voice assistant (useful when wake word is
-# unreliable). The pill briefly shows "Talk now" then returns to "Tap to talk"
-# after 10 s.
+# Long-press the pill to toggle wake-word on/off. Single-tap behaviour:
+#   - if currently disabled -> re-enable wake word (back to Idle/Tap to talk)
+#   - if currently enabled  -> manually start the voice assistant
+# The pill briefly shows "Talk now" then returns to "Tap to talk" after 10 s.
 #
 # vars:
 #   uid:               unique identifier (default: voice_indicator)
@@ -37,11 +36,13 @@
 #                      REQUIRED.
 #
 # Optional theme overrides (any can be omitted to use the defaults shown):
-#   idle_bg_color:        (default: 0x222244)
-#   idle_border_color:    (default: 0x444466)
-#   idle_text_color:      (default: 0x666677)
-#   listening_bg_color:   (default: 0x1565C0)
-#   listening_border_color: (default: 0x90CAF9)
+#   idle_bg_color:           (default: 0x222244)
+#   idle_border_color:       (default: 0x444466)
+#   idle_text_color:         (default: 0x666677)
+#   listening_bg_color:      (default: 0x1565C0)
+#   listening_border_color:  (default: 0x90CAF9)
+#   disabled_bg_color:       (default: 0x6A1B1B)
+#   disabled_border_color:   (default: 0xFF8A80)
 
 globals:
   # Suppresses on_click that LVGL fires after on_long_press release (used by
@@ -78,17 +79,66 @@ lvgl:
               then:
               - logger.log: "voice indicator on_click suppressed (long-press tail)"
               else:
-              - micro_wake_word.stop:
-              - delay: 150ms
-              - voice_assistant.start:
-              - lvgl.label.update:
-                  id: ${uid | default("voice_indicator")}_label
-                  text: "Talk now"
-              - delay: 10s
-              - lvgl.label.update:
-                  id: ${uid | default("voice_indicator")}_label
-                  text: "Tap to talk"
-              - micro_wake_word.start:
+              - if:
+                  condition:
+                    lambda: 'return id(wake_word_user_disabled);'
+                  then:
+                    # User disabled -> single tap re-enables wake word
+                    - globals.set: { id: wake_word_user_disabled, value: 'false' }
+                    - micro_wake_word.start:
+                    - lvgl.label.update:
+                        id: ${uid | default("voice_indicator")}_label
+                        text: "Tap to talk"
+                    - lvgl.widget.update:
+                        id: ${uid | default("voice_indicator")}
+                        bg_color: ${idle_bg_color | default(0x222244)}
+                        border_color: ${idle_border_color | default(0x444466)}
+                  else:
+                    # Wake word enabled -> single tap starts a manual conversation
+                    - micro_wake_word.stop:
+                    - delay: 150ms
+                    - voice_assistant.start:
+                    - lvgl.label.update:
+                        id: ${uid | default("voice_indicator")}_label
+                        text: "Talk now"
+                    - delay: 10s
+                    - lvgl.label.update:
+                        id: ${uid | default("voice_indicator")}_label
+                        text: "Tap to talk"
+                    - micro_wake_word.start:
+        on_long_press:
+          then:
+          # Long-press toggles wake-word user-disable.
+          - globals.set:
+              id: ${uid | default("voice_indicator")}_long_press_guard
+              value: 'true'
+          - lambda: 'id(wake_word_user_disabled) = !id(wake_word_user_disabled);'
+          - if:
+              condition:
+                lambda: 'return id(wake_word_user_disabled);'
+              then:
+                - micro_wake_word.stop:
+                - lvgl.label.update:
+                    id: ${uid | default("voice_indicator")}_label
+                    text: "Wake OFF"
+                - lvgl.widget.update:
+                    id: ${uid | default("voice_indicator")}
+                    bg_color: ${disabled_bg_color | default(0x6A1B1B)}
+                    border_color: ${disabled_border_color | default(0xFF8A80)}
+              else:
+                - micro_wake_word.start:
+                - lvgl.label.update:
+                    id: ${uid | default("voice_indicator")}_label
+                    text: "Tap to talk"
+                - lvgl.widget.update:
+                    id: ${uid | default("voice_indicator")}
+                    bg_color: ${idle_bg_color | default(0x222244)}
+                    border_color: ${idle_border_color | default(0x444466)}
+          # Hold the click-suppress guard past LVGL's click-on-release window.
+          - delay: 600ms
+          - globals.set:
+              id: ${uid | default("voice_indicator")}_long_press_guard
+              value: 'false'
         widgets:
         - label:
             id: ${uid | default("voice_indicator")}_label
@@ -104,6 +154,16 @@ text_sensor:
     on_value:
       then:
         - lambda: |-
+            // If the user has disabled wake word, hold the "Wake OFF" red state
+            // and don't let HA pipeline updates overwrite it.
+            if (id(wake_word_user_disabled)) {
+              lv_label_set_text(id(${uid | default("voice_indicator")}_label), "Wake OFF");
+              lv_obj_set_style_bg_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${disabled_bg_color | default(0x6A1B1B)}), 0);
+              lv_obj_set_style_border_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${disabled_border_color | default(0xFF8A80)}), 0);
+              return;
+            }
             if (x == "Listening") {
               lv_label_set_text(id(${uid | default("voice_indicator")}_label), "Listening");
               lv_obj_set_style_bg_color(id(${uid | default("voice_indicator")}),

--- a/ui/voice/indicator_pill.yaml
+++ b/ui/voice/indicator_pill.yaml
@@ -1,0 +1,119 @@
+---
+# Voice Indicator Pill
+#
+# A compact pill-shaped status widget that reflects the current state of the
+# Home Assistant voice pipeline running on this device. Designed to live in a
+# single grid cell on the main page (typically next to a volume button on the
+# bottom row of an audio screen).
+#
+# State colour map (driven by the HA voice pipeline status text_sensor):
+#   - Idle / wake-word running -> dark navy   (label "Tap to talk" / "Idle")
+#   - HA pipeline listening    -> dark blue   (label "Listening")
+#
+# Downstream configs can drive additional states by writing to the pill
+# directly, e.g.:
+#   - lvgl.label.update:  { id: voice_indicator_label, text: "Heard!" }
+#   - lvgl.widget.update:
+#       id: voice_indicator
+#       bg_color: 0x1B5E20
+#       border_color: 0x69F0AE
+#
+# Tap the pill to manually start the voice assistant (useful when wake word is
+# unreliable). The pill briefly shows "Talk now" then returns to "Tap to talk"
+# after 10 s.
+#
+# vars:
+#   uid:               unique identifier (default: voice_indicator)
+#   page_id:           parent page (default: main_page)
+#   row:               grid row position (REQUIRED)
+#   column:            grid column position (REQUIRED)
+#   row_span:          (default: 1)
+#   column_span:       (default: 1)
+#   width:             pill width in px  (default: 100)
+#   height:            pill height in px (default: 40)
+#   voice_status_entity_id:
+#                      HA text_sensor entity_id that carries the voice pipeline
+#                      state (typically "sensor.<device_name>_voice_assistant_status")
+#                      REQUIRED.
+#
+# Optional theme overrides (any can be omitted to use the defaults shown):
+#   idle_bg_color:        (default: 0x222244)
+#   idle_border_color:    (default: 0x444466)
+#   idle_text_color:      (default: 0x666677)
+#   listening_bg_color:   (default: 0x1565C0)
+#   listening_border_color: (default: 0x90CAF9)
+
+globals:
+  # Suppresses on_click that LVGL fires after on_long_press release (used by
+  # downstream extensions such as a long-press wake-word disable toggle).
+  - id: ${uid | default("voice_indicator")}_long_press_guard
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+lvgl:
+  pages:
+  - id: !extend ${page_id | default("main_page")}
+    widgets:
+    - obj:
+        id: ${uid | default("voice_indicator")}
+        grid_cell_row_pos: ${row}
+        grid_cell_column_pos: ${column}
+        grid_cell_row_span: ${row_span | default(1)}
+        grid_cell_column_span: ${column_span | default(1)}
+        grid_cell_x_align: center
+        grid_cell_y_align: end
+        width: ${width | default(100)}
+        height: ${height | default(40)}
+        bg_color: ${idle_bg_color | default(0x222244)}
+        radius: 8
+        border_width: 1
+        border_color: ${idle_border_color | default(0x444466)}
+        clickable: true   # REQUIRED — obj does not receive clicks otherwise
+        on_click:
+          then:
+          - if:
+              condition:
+                lambda: 'return id(${uid | default("voice_indicator")}_long_press_guard);'
+              then:
+              - logger.log: "voice indicator on_click suppressed (long-press tail)"
+              else:
+              - micro_wake_word.stop:
+              - delay: 150ms
+              - voice_assistant.start:
+              - lvgl.label.update:
+                  id: ${uid | default("voice_indicator")}_label
+                  text: "Talk now"
+              - delay: 10s
+              - lvgl.label.update:
+                  id: ${uid | default("voice_indicator")}_label
+                  text: "Tap to talk"
+              - micro_wake_word.start:
+        widgets:
+        - label:
+            id: ${uid | default("voice_indicator")}_label
+            text: "Tap to talk"
+            text_font: $text_font
+            text_color: ${idle_text_color | default(0x666677)}
+            align: center
+
+text_sensor:
+  - platform: homeassistant
+    id: ${uid | default("voice_indicator")}_pipeline_state
+    entity_id: ${voice_status_entity_id}
+    on_value:
+      then:
+        - lambda: |-
+            if (x == "Listening") {
+              lv_label_set_text(id(${uid | default("voice_indicator")}_label), "Listening");
+              lv_obj_set_style_bg_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${listening_bg_color | default(0x1565C0)}), 0);
+              lv_obj_set_style_border_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${listening_border_color | default(0x90CAF9)}), 0);
+            } else {
+              lv_label_set_text(id(${uid | default("voice_indicator")}_label), "Idle");
+              lv_obj_set_style_bg_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${idle_bg_color | default(0x222244)}), 0);
+              lv_obj_set_style_border_color(id(${uid | default("voice_indicator")}),
+                lv_color_hex(${idle_border_color | default(0x444466)}), 0);
+            }


### PR DESCRIPTION
> ⚠️ **Stacked on #99** — base this on `feat/voice-indicator-pill`. Please merge #99 first, then this. After #99 merges into `main`, GitHub will automatically retarget the diff against `main` and the diff will shrink to only the changes here.

Adds the missing wake-word user-disable plumbing and the green "Heard!" / red "Wake OFF" pill states, so screens including both `hardware/media_player-voice_assistant.yaml` and `ui/voice/indicator_pill.yaml` get the complete Idle / Listening / Heard / Wake OFF UX with **zero per-screen YAML**.

## Why

Two long-standing per-screen patches we (and probably others) have been carrying:

1. **Wake-word user-disable.** Today the package restarts `micro_wake_word` from three internal callsites (`media_player.on_idle`, `voice_assistant.on_end`, `voice_assistant.on_client_connected`). If the user wants to silence the satellite for a while (e.g. baby asleep), they have no clean way — they have to either set a `select.wake_word` in HA or hack a 2 s polling interval that re-stops the wake word every cycle. Both feel wrong.

2. **Wake-word visual confirmation.** When the wake word fires, there's no UI feedback until HA's pipeline pushes back a `Listening` state — typically half a second to a few seconds later. A short green "Heard!" flash before that closes the loop and noticeably improves perceived responsiveness.

This PR lands both, the right way, in two places.

## What's in `hardware/media_player-voice_assistant.yaml`

- **New global** `wake_word_user_disabled` — `bool`, `restore_value: true`, `initial_value: 'false'`. Sticky across reboots so the user's choice survives.
- **All three internal `micro_wake_word.start:` callsites** wrapped in `if: condition: lambda: 'return !id(wake_word_user_disabled);'`. Stop is intentionally not gated (always safe and idempotent).
- **`on_wake_word_detected`** now flashes the pill green (`bg 0x1B5E20`, `border 0x69F0AE`) with label `"Heard!"` before `voice_assistant.start:`. Pipeline `text_sensor` (in the pill package) overwrites it with the next state shortly after.

The new `on_wake_word_detected` `lvgl.*` lines reference the pill package's default IDs (`voice_indicator` and `voice_indicator_label`). Configs that include `hardware/media_player-voice_assistant.yaml` **without** the pill package will fail at compile time with "unknown id" — in that case either include the pill package or remove those three lines. (Happy to gate this with a substitution if you prefer; see "alternatives" below.)

## What's in `ui/voice/indicator_pill.yaml`

- **`on_click` is now context-aware.** If wake word is currently user-disabled, tap re-enables it and restores the navy idle theme. Otherwise tap manually starts a `voice_assistant` conversation (the existing "Talk now" 10 s flow).
- **`on_long_press` toggles `wake_word_user_disabled`.** Disabled state shows label `"Wake OFF"` on a dark red pill (`0x6A1B1B / 0xFF8A80`). Uses the existing `${uid}_long_press_guard` to prevent the LVGL click-on-release from immediately re-toggling.
- **`text_sensor.on_value` lambda checks `wake_word_user_disabled` first** and holds the "Wake OFF" style sticky, so an HA pipeline state push does not overwrite the user's choice.
- **New optional vars** for the disabled-state theme:
  - `disabled_bg_color` (default `0x6A1B1B`)
  - `disabled_border_color` (default `0xFF8A80`)
- **No new required vars.** Existing usage of the package keeps working unchanged.

## Compatibility

| Combination | Behaviour |
|---|---|
| hardware + pill (recommended) | Full Idle / Listening / Heard / Wake OFF UX, no per-screen YAML |
| hardware only (no pill) | Compile fails on the new `lvgl.*` lines in `on_wake_word_detected` because `voice_indicator` / `voice_indicator_label` don't exist. Either include the pill package or remove those three lines. |
| pill only (no hardware) | Compile fails because the pill now references `wake_word_user_disabled`. The pill always required the hardware package anyway (for `voice_assistant`/`micro_wake_word`), so this isn't a regression. |
| neither | Unchanged. |

## Alternatives considered

- **Substitution-gating the `on_wake_word_detected` pill update** so the hardware file works standalone. Doable (`${voice_indicator_id | default("")}` + an `if` check) but uglier; happy to add if you want.
- **Putting the global declaration in the pill package instead of the hardware file.** Rejected because the hardware file owns the three callsites that read the global; declaring there keeps the dependency direction clean (pill depends on hardware, never the reverse).

## Tested

- Compiles cleanly and OTAs to a Waveshare ESP32-P4-WIFI6-Touch-LCD-10.1 audio screen (long-press toggles, "Wake OFF" sticky across HA pipeline updates, "Heard!" flash visible before "Listening" overwrites it, sticky disable survives reboot).
