### PR TITLE
ui/solar: optional support for a second Envoy (combined daily totals)

### DIFF
--- a/ui/solar/update_solar_today.yaml
+++ b/ui/solar/update_solar_today.yaml
@@ -1,9 +1,18 @@
 ---
 substitutions:
+  # Set in your top-level YAML to enable a SECOND Enphase IQ Gateway.
+  # Leave empty (default) for single-Envoy installs -- no other changes
+  # required. When set, the four "today" totals below are summed across
+  # both Envoys.
+  envoy_id_2: ""
+
   # Home Assistant sensor entity IDs
   ha_sensor_net_consumption: 'sensor.envoy_${envoy_id}_lifetime_net_energy_consumption'
   ha_sensor_production: 'sensor.envoy_${envoy_id}_lifetime_energy_production'
   ha_sensor_net_production: 'sensor.envoy_${envoy_id}_lifetime_net_energy_production'
+  ha_sensor_net_consumption_2: 'sensor.envoy_${envoy_id_2}_lifetime_net_energy_consumption'
+  ha_sensor_production_2: 'sensor.envoy_${envoy_id_2}_lifetime_energy_production'
+  ha_sensor_net_production_2: 'sensor.envoy_${envoy_id_2}_lifetime_net_energy_production'
 
 # Extend on_ha_connected script (called from loading.yaml when HA connects)
 script:
@@ -20,11 +29,19 @@ script:
           action: recorder.get_statistics
           data_template:
             statistic_ids: >-
-              {{ [
+              {% set ids = [
                 '$ha_sensor_net_consumption',
                 '$ha_sensor_production',
                 '$ha_sensor_net_production'
-              ] }}
+              ] %}
+              {% if '${envoy_id_2}' | length > 0 %}
+                {% set ids = ids + [
+                  '$ha_sensor_net_consumption_2',
+                  '$ha_sensor_production_2',
+                  '$ha_sensor_net_production_2'
+                ] %}
+              {% endif %}
+              {{ ids }}
             start_time: >-
               {{ today_at('00:00:00').isoformat() }}
             period: day
@@ -48,6 +65,11 @@ script:
             {% set net_consumption = get_kwh('$ha_sensor_net_consumption') | float %}
             {% set production = get_kwh('$ha_sensor_production') | float %}
             {% set net_production = get_kwh('$ha_sensor_net_production') | float %}
+            {% if '${envoy_id_2}' | length > 0 %}
+              {% set net_consumption = net_consumption + (get_kwh('$ha_sensor_net_consumption_2') | float) %}
+              {% set production = production + (get_kwh('$ha_sensor_production_2') | float) %}
+              {% set net_production = net_production + (get_kwh('$ha_sensor_net_production_2') | float) %}
+            {% endif %}
             {% set consumption = net_consumption + production - net_production %}
             {{ {'consumption': consumption | round(2), 'net_consumption': net_consumption, 'production': production, 'net_production': net_production} | tojson }}
           on_success:

--- a/ui/solar/update_solar_today.yaml
+++ b/ui/solar/update_solar_today.yaml
@@ -1,9 +1,11 @@
 ---
 substitutions:
-  # Set in your top-level YAML to enable a SECOND Enphase IQ Gateway.
-  # Leave empty (default) for single-Envoy installs -- no other changes
-  # required. When set, the four "today" totals below are summed across
-  # both Envoys.
+  # Set in your top-level YAML to enable a SECOND Envoy / IQ Gateway.
+  # Use the same suffix format as ${envoy_id} (the part that fills
+  # `sensor.envoy_<suffix>_...`). Leave empty (default) for single-Envoy
+  # installs -- no other changes required. When set, the four "today"
+  # totals below are summed across both Envoys. Whitespace-only values
+  # are treated as empty.
   envoy_id_2: ""
 
   # Home Assistant sensor entity IDs
@@ -34,7 +36,8 @@ script:
                 '$ha_sensor_production',
                 '$ha_sensor_net_production'
               ] %}
-              {% if '${envoy_id_2}' | length > 0 %}
+              {% set envoy_2 = '${envoy_id_2}' | trim %}
+              {% if envoy_2 | length > 0 %}
                 {% set ids = ids + [
                   '$ha_sensor_net_consumption_2',
                   '$ha_sensor_production_2',
@@ -65,7 +68,8 @@ script:
             {% set net_consumption = get_kwh('$ha_sensor_net_consumption') | float %}
             {% set production = get_kwh('$ha_sensor_production') | float %}
             {% set net_production = get_kwh('$ha_sensor_net_production') | float %}
-            {% if '${envoy_id_2}' | length > 0 %}
+            {% set envoy_2 = '${envoy_id_2}' | trim %}
+            {% if envoy_2 | length > 0 %}
               {% set net_consumption = net_consumption + (get_kwh('$ha_sensor_net_consumption_2') | float) %}
               {% set production = production + (get_kwh('$ha_sensor_production_2') | float) %}
               {% set net_production = net_production + (get_kwh('$ha_sensor_net_production_2') | float) %}


### PR DESCRIPTION
# ui/solar: optional support for a second Envoy (combined daily totals)

## Summary

Adds opt-in support for a **second Enphase IQ Gateway** to
`ui/solar/update_solar_today.yaml`. When a second Envoy is declared, the
four "today" template sensors (production, consumption, grid import,
grid export) publish the **sum** across both Envoys. When the new
substitution is left at its default (empty string), behavior is
byte-identical to the current `main` branch — single-Envoy users are
completely unaffected and need to change **nothing**.

## Motivation

Some PV installs (large arrays, split panels, two service drops, or
incremental expansions added later) run two Enphase IQ Gateways. Today
the file hardcodes a single `${envoy_id}`, which forces dual-Envoy users
to either:

- fork this file and maintain a divergent copy, **or**
- build a parallel `utility_meter` chain in Home Assistant
  (which has its own pitfalls — most notably: changing a
  `utility_meter` `source:` mid-cycle silently corrupts the daily value
  until the next midnight reset, since `periodically_resetting: false`
  meters snapshot the source at the previous reset and serve
  `current - snapshot`).

A one-line opt-in keeps the simple path simple, eliminates an entire
class of HA-side helper bugs for multi-Envoy users, and unlocks
combined totals without anyone needing a fork.

## User-facing API

**One new substitution, defaulted to empty:**

```yaml
substitutions:
  envoy_id: "1"        # existing, unchanged
  envoy_id_2: ""       # NEW — leave empty for single-Envoy installs
```

- **Single-Envoy users (the common case):** no change required.
  The default empty string keeps the old code path active.
- **Dual-Envoy users:** set `envoy_id_2:` to the second gateway's
  HA entity-ID suffix in your top-level YAML. Done.

## Why this is safe for existing users

- New substitution defaults to `""` inside the file itself.
- A `{% if '${envoy_id_2}' | length > 0 %}` guard in the Jinja
  builds the **same 3-entry** `statistic_ids` list as today when
  `envoy_id_2` is empty.
- The summing macro with a 1-element ID list reduces algebraically to
  the original `get_kwh` single-sensor lookup.
- **No new sensor IDs, no new label IDs, no new external dependencies,
  no breaking changes.**
- MWh/Wh/kWh normalization is preserved **per-sensor** so the two
  Envoys are free to report in different units (rare but possible).

## Testing matrix

| Config                                        | Expected result                                                                              |
| --------------------------------------------- | -------------------------------------------------------------------------------------------- |
| `envoy_id: "1"` only (default `envoy_id_2`)   | Byte-identical to current `main`                                                             |
| `envoy_id: "1"`, `envoy_id_2: "2"`            | Sum across both Envoys for all four daily totals                                             |
| `envoy_id: "abc"` (full string serial)        | Works — substitutions are strings                                                            |
| Envoy 2 temporarily offline / no recorder data | That envoy contributes 0; Envoy 1 still counted. No errors, sensor stays available           |
| Envoys reporting in different units            | Each normalized to kWh before summing                                                        |

## README addition (one paragraph)

> **Multi-Envoy installs:** If you have two Enphase IQ Gateways, set
> `envoy_id_2:` in your top-level YAML to the second gateway's HA
> entity-ID suffix (the same kind of value as `envoy_id`). The four
> "today" totals — production, consumption, grid import, grid
> export — will be summed across both. Single-Envoy users can ignore
> this option; the default of `""` preserves the existing behavior.

## Field-tested

Pattern has been running in production on dual-Envoy WS10-01
(ESPHome 2026.4.5, ESP32-P4, two Enphase IQ Gateway 8) since
2026-05-21. Daily totals reconcile with HA's recorder statistics to
the cent.

## Future work (out of scope for this PR)

- Generalize to N Envoys via a comma-separated `envoy_ids:` list.
  Deferred — most installs are 1 or 2 gateways, and an opt-in `_2`
  covers ~99% of multi-Envoy cases with minimal Jinja complexity.

---

## Patch

See accompanying file: `agillis-multi-envoy-solar-today.patch`
