### PR TITLE
Add opt-in popup auto-close timeout

### DIFF
--- a/ui/light/remote.yaml
+++ b/ui/light/remote.yaml
@@ -338,6 +338,7 @@ script:
       - lvgl.widget.show: popup_scrim
       - lvgl.widget.show: ${uid}_popup
       - script.execute: ${uid}_picker_update
+      - script.execute: popup_auto_close
 
   # Recolor the tile icon to match bulb state.
   - id: ${uid}_update_bulb_color

--- a/ui/popup/popup_system.yaml
+++ b/ui/popup/popup_system.yaml
@@ -44,7 +44,28 @@ image:
         id: kelvin_ring_img
         resize: 300x300
 
+substitutions:
+  # Auto-close popups after this many seconds. "0" disables (default).
+  # Override per-screen in the top-level YAML's substitutions block, e.g.
+  #     substitutions:
+  #       popup_timeout_seconds: "15"
+  popup_timeout_seconds: "0"
+
 script:
+  # Auto-close current popup after popup_timeout_seconds. mode: restart so
+  # callers can re-execute on user interaction (e.g. on_press handlers in the
+  # popup widgets) to defer the close. When popup_timeout_seconds is "0" the
+  # script is a no-op, making this opt-in and zero-cost when unused.
+  - id: popup_auto_close
+    mode: restart
+    then:
+      - if:
+          condition:
+            lambda: 'return ${popup_timeout_seconds} > 0;'
+          then:
+            - delay: ${popup_timeout_seconds}s
+            - script.execute: popup_close
+
   # Extended by each popup file to hide its own widget.
   - id: popup_close
     then:


### PR DESCRIPTION
# PR: Opt-in popup auto-close timeout

## Why

Popups (currently the new color-picker popup, and likely future ones) can get
left open if the user wanders off, hiding the underlying page. Adds a
zero-cost, opt-in inactivity timer driven entirely by a single substitution.

## What

- `ui/popup/popup_system.yaml`:
  - Adds `popup_timeout_seconds` substitution (default `"0"` = disabled).
  - Adds `popup_auto_close` script (`mode: restart`). When the substitution
    is `"0"` the script body is gated by an `if` and exits immediately, so
    there's no runtime cost for screens that don't enable it.
- `ui/light/remote.yaml`:
  - `${uid}_show_popup` script now also calls `popup_auto_close` after
    showing the popup.

## Usage

In a top-level screen YAML:

```yaml
substitutions:
  popup_timeout_seconds: "15"
```

Pop-up will close after 15s. Default-off semantics preserved.

## Reset-on-interaction (forward-compatible)

`popup_auto_close` is `mode: restart` so any popup widget can re-execute it
from `on_press` to defer the close while the user is interacting. The
current PR doesn't wire that into the color-picker widgets — kept minimal.
A follow-up can add `- script.execute: popup_auto_close` to relevant
widget handlers if desired.

## Other popups

This PR only opts the color-picker into auto-close (since that's where it
lives via `_show_popup`). Adding it to a new popup is one line in that
popup's "show" path:

```yaml
- lvgl.widget.show: popup_scrim
- lvgl.widget.show: popup_<name>
- script.execute: popup_auto_close
```

## Tested

ESPHome 2026.4.5, ESP32-P4 (Waveshare 10.1" tablet, WS10-01). Build clean,
OTA successful, color picker confirmed closing at 15s and reopening cleanly.
