### PR TITLE
feat(light/remote) add support for minimum and maximum Kelvin temperature

### DIFF
--- a/ui/light/remote.yaml
+++ b/ui/light/remote.yaml
@@ -322,6 +322,34 @@ text_sensor:
                    id(${uid}_supports_brightness),
                    has_rgbww, has_rgbw, has_hs, has_xy, has_white, has_br);
 
+  - id: ${uid}_ha_min_kelvin
+    platform: homeassistant
+    entity_id: ${entity_id}
+    attribute: min_color_temp_kelvin
+    internal: true
+    on_value:
+      - if:
+          condition:
+            lambda: 'return !x.empty() && x != "None";'
+          then:
+            - lvgl.arc.update:
+                id: ${uid}_kelvin_arc
+                min_value: !lambda return (int) atof(x.c_str());
+
+  - id: ${uid}_ha_max_kelvin
+    platform: homeassistant
+    entity_id: ${entity_id}
+    attribute: max_color_temp_kelvin
+    internal: true
+    on_value:
+      - if:
+          condition:
+            lambda: 'return !x.empty() && x != "None";'
+          then:
+            - lvgl.arc.update:
+                id: ${uid}_kelvin_arc
+                max_value: !lambda return (int) atof(x.c_str());
+
 
 # ── Scripts ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
This PR adds support for Home Assistant provided light attributes `min_color_temp_kelvin` and `max_color_temp_kelvin`.

It uses a similar way to to retrieve them to `${uid}_ha_supported_modes`.

New HA Text Sensors:
- `${uid}_ha_min_kelvin`
- `${uid}_ha_max_kelvin`

No modification of `color_picker` necessary. No suspend send necessary either as `on_value` is not triggered. 
No new global variables used as the retrieved values are not re-used.

Linting should be ok.

Tested on personal HA setup (Ikea KAJPLATS lamps + Waveshare Touch 4.3b with custom yaml configuration - still very similar to that in `hardware/` and `example_code/`)

Feel free to make comments/suggestions!