### PR TITLE
Add Sunton ESP32-S3 8048S043 hardware config

### DIFF
--- a/hardware/sunton-esp32-8048s043.yaml
+++ b/hardware/sunton-esp32-8048s043.yaml
@@ -1,0 +1,117 @@
+# Sunton 4.3" ESP32-S3-8048S043 480px X 800px Smart Screen with Capacitive Touch Controller
+# This file is for v1.1 or greater of this screen. the version is right next to the SD card slot.
+#
+# Hardware configuration file
+---
+esphome:
+  min_version: 2026.7.0
+  project:
+    name: "Sunton.ESP32-S3-8048S043"
+    version: "1.0"
+
+esp32:
+  variant: esp32s3
+  flash_size: 16MB
+  framework:
+    type: esp-idf
+    advanced:
+      execute_from_psram: true
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+preferences:
+  flash_write_interval: 5min
+
+# -------------------------------------------
+# Backlight
+# -------------------------------------------
+output:
+  - platform: ledc
+    pin: GPIO2
+    id: backlight_pwm
+
+light:
+  - platform: monochromatic
+    id: display_backlight
+    output: backlight_pwm
+    restore_mode: ALWAYS_ON
+
+# -------------------------------------------
+# Touchscreen gt911 i2c
+# -------------------------------------------
+i2c:
+  - id: bus_a
+    sda: 19
+    scl: 20
+    scan: true
+
+touchscreen:
+  platform: gt911
+  id: touch
+  display: my_display
+  i2c_id: bus_a
+  address: 0x5D
+
+  transform:
+    swap_xy: false
+    mirror_x: false
+    mirror_y: false
+# on_touch:
+#   - logger.log:
+#       format: Touch at (%d, %d)
+#       args: [touch.x, touch.y]
+#   - lambda: |-
+#       ESP_LOGI("cal", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
+#           touch.x,
+#           touch.y,
+#           touch.x_raw,
+#           touch.y_raw
+#           );
+
+# -------------------------------------------
+# Display EK9716 (raw RGB panel)
+# Migrated from the deprecated rpi_dpi_rgb component to mipi_rgb.
+# Notes:
+#   - model: RPI selects the generic raw-RGB driver (no SPI controller).
+#   - pclk_inverted: true matches the original rpi_dpi_rgb config and
+#     also happens to be the mipi_rgb default.
+#   - The hsync/vsync porch values are panel-specific and carried over
+#     verbatim from the rpi_dpi_rgb config.
+# -------------------------------------------
+display:
+  - platform: mipi_rgb
+    id: my_display
+    model: RPI
+    color_order: RGB
+    invert_colors: false
+    update_interval: never
+    auto_clear_enabled: false
+
+    dimensions:
+      width: 800
+      height: 480
+
+    de_pin: 40
+    hsync_pin: 39
+    vsync_pin: 41
+    pclk_pin: 42
+    pclk_frequency: 16MHz
+
+    hsync_front_porch: 8
+    hsync_pulse_width: 4
+    hsync_back_porch: 8
+
+    vsync_front_porch: 8
+    vsync_pulse_width: 4
+    vsync_back_porch: 8
+
+    data_pins:
+      red: [45, 48, 47, 21, 14]
+      green: [5, 6, 7, 15, 16, 4]
+      blue: [8, 3, 46, 9, 1]
+
+# Special LVGL settings required for this display
+lvgl:
+  rotation: ${rotation | default("0")}


### PR DESCRIPTION
Add hardware definition for the Sunton 4.3" ESP32-S3-8048S043 smart screen. Configures esp32s3 (esp-idf), PSRAM, backlight PWM, GT911 touchscreen on I2C, and an mipi_rgb display (800×480) with panel timings and data pins. Includes LVGL rotation substitution and esphome min_version 2026.7.0.